### PR TITLE
Fix / Participant Member in meeting

### DIFF
--- a/src/components/organisms/modals/MeetingEditModal.tsx
+++ b/src/components/organisms/modals/MeetingEditModal.tsx
@@ -174,13 +174,16 @@ export default function MeetingEditModal({
   const onSubmit = handleSubmit(async ({ startDate, duration, ...data }) => {
     if (!orgId || !currentMember) return
     const startDateDate = new Date(startDate)
+    const membersIdsWithScope = participants.map(
+      (participant) => participant.member.id
+    )
     const meetingUpdate = {
       ...data,
       startDate: Timestamp.fromDate(startDateDate),
       endDate: Timestamp.fromDate(
         new Date(startDateDate.getTime() + duration * 60 * 1000)
       ),
-      participantsMembersIds,
+      participantsMembersIds: membersIdsWithScope,
     }
     if (meeting) {
       // Update meeting


### PR DESCRIPTION
Seul les membres "invités" dans un meeting étaient ajoutés dans la liste des users d'un meeting.
Les membre du scope était ajouté au participant par procuration dans le hook `useParticipants.ts`

Les membres d'un cercle n'avaient pas le meeting d'affiché dans leur calendrier.

Ici on fait attention a ce que la liste des IDs des participants d'un meeting soit égale à celle des participants récupéré via le hook lors de la création ou de l'update d'un meeting (comprenant les participant par procuration du scope).