### PR TITLE
Fix Nestr alternative post: Rolebase has formal governance proposals

### DIFF
--- a/website/src/content/blog/alternative-nestr/en.mdx
+++ b/website/src/content/blog/alternative-nestr/en.mdx
@@ -71,7 +71,7 @@ The "All Roles" view displays the full hierarchy with role sizes reflecting the 
 
 ### Framework-agnostic design
 
-While Nestr leans heavily into holacracy-specific workflows, Rolebase takes a more flexible approach. It provides the building blocks (roles, accountabilities, circles, meetings, decisions) without enforcing a specific methodology. Whether your team practices holacracy, sociocracy, or a custom blend of self-management principles, Rolebase adapts to your way of working rather than requiring you to adapt to its framework. As stated in their FAQ: "We believe a good tool should make life easier without being too restrictive."
+While Nestr leans heavily into holacracy-specific workflows, Rolebase takes a more flexible approach. It provides the building blocks (roles, accountabilities, circles, meetings, governance proposals, decisions) without enforcing a specific methodology. Whether your team practices holacracy, sociocracy, or a custom blend of self-management principles, Rolebase adapts to your way of working rather than requiring you to adapt to its framework. As stated in their FAQ: "We believe a good tool should make life easier without being too restrictive."
 
 This matters because many organizations evolve their governance practices over time. A team might start with elements of sociocracy, gradually incorporate holacratic meeting formats, and develop their own unique decision-making processes. A tool that locks you into one framework becomes a constraint rather than an enabler as your practices mature. Rolebase gives you the freedom to experiment and iterate on your governance model without outgrowing the platform.
 
@@ -91,7 +91,7 @@ Here is a side-by-side comparison of key features. This information is accurate 
 | --- | --- | --- |
 | **Org chart visualization** | Dynamic, 4 views, zoomable | Circle/role map |
 | **Roles and accountabilities** | Yes, with purpose and domain | Yes, with policies |
-| **Governance proposals** | Decisions recorded per circle | Formal proposal workflow |
+| **Governance proposals** | Formal proposals with voting (consent, majority) and staged org chart changes | Formal proposal workflow |
 | **Meeting facilitation** | Step-based with timer and templates | Structured meeting formats |
 | **Real-time collaboration** | Yes, during meetings and editing | Yes |
 | **Task management** | Tasks linked to roles and circles | Project boards and todo lists |
@@ -139,7 +139,7 @@ The open source option adds another dimension to the comparison. If your organiz
 
 **Choose Nestr if:**
 - You want an all-in-one platform that replaces your chat, project management, and governance tools
-- Your team follows strict holacracy and you value built-in governance proposal workflows
+- Your team wants holacracy-specific vocabulary and workflows baked into every screen
 - You need AI-powered features like automatic organizational structure generation
 - OKRs and peer feedback are important to your workflow
 - DAO integrations are relevant to your organization

--- a/website/src/content/blog/alternative-nestr/fr.mdx
+++ b/website/src/content/blog/alternative-nestr/fr.mdx
@@ -71,7 +71,7 @@ La vue "Tous les rôles" affiche la hiérarchie complète avec des tailles de r�
 
 ### Un outil agnostique en termes de cadre méthodologique
 
-Là où Nestr s'appuie fortement sur des workflows spécifiques à l'holacratie, Rolebase adopte une approche plus flexible. Il fournit les briques de base (rôles, redevabilités, cercles, réunions, décisions) sans imposer une méthodologie particulière. Que votre équipe pratique l'holacratie, la sociocratie ou un mélange personnalisé de principes d'autogouvernance, Rolebase s'adapte à votre manière de travailler plutôt que de vous demander de vous adapter à son cadre. Comme l'indique leur FAQ : "Nous pensons qu'un bon outil doit faciliter la vie sans être trop contraignant."
+Là où Nestr s'appuie fortement sur des workflows spécifiques à l'holacratie, Rolebase adopte une approche plus flexible. Il fournit les briques de base (rôles, redevabilités, cercles, réunions, propositions de gouvernance, décisions) sans imposer une méthodologie particulière. Que votre équipe pratique l'holacratie, la sociocratie ou un mélange personnalisé de principes d'autogouvernance, Rolebase s'adapte à votre manière de travailler plutôt que de vous demander de vous adapter à son cadre. Comme l'indique leur FAQ : "Nous pensons qu'un bon outil doit faciliter la vie sans être trop contraignant."
 
 ### Des réunions structurées avec collaboration en temps réel
 
@@ -89,7 +89,7 @@ Voici un comparatif côte à côte des fonctionnalités clés. Ces informations 
 | --- | --- | --- |
 | **Visualisation de l'organigramme** | Dynamique, 4 vues, zoomable | Carte des cercles/rôles |
 | **Rôles et redevabilités** | Oui, avec raison d'être et domaine | Oui, avec politiques |
-| **Propositions de gouvernance** | Décisions enregistrées par cercle | Workflow formel de proposition |
+| **Propositions de gouvernance** | Propositions formelles avec vote (consentement, majorité) et modifications d'organigramme préparées | Workflow formel de proposition |
 | **Facilitation de réunions** | Par étapes avec minuteur et modèles | Formats de réunion structurés |
 | **Collaboration en temps réel** | Oui, pendant les réunions et l'édition | Oui |
 | **Gestion des tâches** | Tâches liées aux rôles et cercles | Tableaux de projets et listes de tâches |
@@ -137,7 +137,7 @@ L'option open source ajoute une dimension supplémentaire à la comparaison. Si 
 
 **Choisissez Nestr si :**
 - Vous souhaitez une plateforme tout-en-un qui remplace votre chat, votre gestion de projets et vos outils de gouvernance
-- Votre équipe suit une holacratie stricte et vous appréciez les workflows intégrés de propositions de gouvernance
+- Votre équipe souhaite un vocabulaire et des workflows spécifiques à l'holacratie intégrés à chaque écran
 - Vous avez besoin de fonctionnalités IA comme la génération automatique de structure organisationnelle
 - Les OKR et le feedback entre pairs font partie intégrante de votre fonctionnement
 - Les intégrations DAO sont pertinentes pour votre organisation


### PR DESCRIPTION
The comparison wrongly implied Rolebase only records decisions per
circle while Nestr had a formal proposal workflow. Rolebase now ships
a governance proposals module (voting by consent/majority, staged org
chart changes applied on approval), so update the comparison table,
the framework-agnostic building blocks list, and the 'Choose Nestr if'
section in both EN and FR.